### PR TITLE
Add broadcast progress indicators to parameter dialogs

### DIFF
--- a/app/frontend/components/features/ClusteringAnalyse.vue
+++ b/app/frontend/components/features/ClusteringAnalyse.vue
@@ -30,6 +30,7 @@
       :on-file-selected="onFileSelected"
       :progress="progress"
       :job-id="props.jobId"
+      @progress-update="(p) => (progress.value = p)"
       @analysed="handleAnalysed"
     />
   </div>

--- a/app/frontend/components/features/ClusteringGenerate.vue
+++ b/app/frontend/components/features/ClusteringGenerate.vue
@@ -42,6 +42,7 @@
       :on-file-selected="onFileSelected"
       :progress="progress"
       :job-id="props.jobId"
+      @progress-update="(p) => (progress.value = p)"
       @generated="handleGenerated"
     />
   </div>

--- a/app/frontend/components/features/MusicGenerate.vue
+++ b/app/frontend/components/features/MusicGenerate.vue
@@ -130,6 +130,7 @@
     <MusicGenerateDialog
       v-model="setDataDialog"
       :progress="progress"
+      @progress-update="(p) => (progress.value = p)"
       @generated-polyphonic="handleGenerated"
     />
   </div>
@@ -465,10 +466,10 @@ const handleGenerated = (data: PolyphonicResponse) => {
   generate.value.clusters.hrd    = data.clusters.hrd
   generate.value.clusters.tex    = data.clusters.tex
 
+  progress.value = { percent: 100, status: 'rendering' }
   renderPolyphonicAudio(ts)
 }
 const renderPolyphonicAudio = (timeSeries) => {
-  progress.value.status = 'rendering'
   const stepDuration = 1 / 4.0
   axios.post('/api/web/supercolliders/render_polyphonic', {
     time_series: timeSeries, step_duration: stepDuration
@@ -485,8 +486,9 @@ const renderPolyphonicAudio = (timeSeries) => {
     audio.value = new Audio(url)
     audio.value.addEventListener('ended', () => nowPlaying.value = false)
     cleanup()
+    progress.value = { percent: 100, status: 'done' }
   })
-  .catch(error => { console.error("Rendering error:", error); music.value.loading = false })
+  .catch(error => { console.error("Rendering error:", error); music.value.loading = false; progress.value = { percent: 0, status: 'idle' } })
 }
 
 const cleanup = () => {


### PR DESCRIPTION
## Summary
- add ActionCable progress subscriptions to clustering analyse/generate and music dialogs and propagate updates to parent features
- show progress percentages beside submit buttons and disable submit actions while processing
- track rendering state for polyphonic audio generation to re-enable controls when work finishes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693434e8cc0c83228866737e2b90171b)